### PR TITLE
Add test stage in AppVeyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,9 @@ build:
   parallel: true
   verbosity: minimal
 
+test_script:
+  - dotnet test Quasar.Common.Tests/Quasar.Common.Tests.csproj --no-build --configuration %CONFIGURATION%
+
 artifacts:
 - path: Bin
   name: binaries


### PR DESCRIPTION
## Summary
- add a `test_script` step in `appveyor.yml` running the Quasar.Common.Tests project

## Testing
- `dotnet test Quasar.Common.Tests/Quasar.Common.Tests.csproj -c Release -v normal` *(fails: Could not find testhost.exe)*

------
https://chatgpt.com/codex/tasks/task_e_6882fc8c2c6c83339661afd1275a624a