### PR TITLE
Fix string array delimiter in ByteConverter

### DIFF
--- a/Quasar.Common.Tests/Utilities/ByteConverter.Tests.cs
+++ b/Quasar.Common.Tests/Utilities/ByteConverter.Tests.cs
@@ -1,0 +1,20 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Quasar.Common.Utilities;
+
+namespace Quasar.Common.Tests.Utilities
+{
+    [TestClass]
+    public class ByteConverterTests
+    {
+        [TestMethod, TestCategory("Utilities")]
+        public void StringArrayRoundTrip()
+        {
+            var input = new[] { "first", "second", "third" };
+
+            var bytes = ByteConverter.GetBytes(input);
+            var output = ByteConverter.ToStringArray(bytes);
+
+            CollectionAssert.AreEqual(input, output);
+        }
+    }
+}

--- a/Quasar.Common/Utilities/ByteConverter.cs
+++ b/Quasar.Common/Utilities/ByteConverter.cs
@@ -110,9 +110,10 @@ namespace Quasar.Common.Utilities
             StringBuilder strBuilder = new StringBuilder(bytes.Length);
             while (i < bytes.Length)
             {
-                //Holds the number of nulls (3 nulls indicated end of a string)
+                // Holds the number of encountered null bytes. Two consecutive null
+                // bytes indicate the end of a string entry.
                 int nullcount = 0;
-                while (i < bytes.Length && nullcount < 3)
+                while (i < bytes.Length && nullcount < 2)
                 {
                     if (bytes[i] == NULL_BYTE)
                     {


### PR DESCRIPTION
## Summary
- fix null byte delimiter logic in `ByteConverter.BytesToStringArray`
- add `ByteConverterTests.StringArrayRoundTrip` covering string array conversion

## Testing
- `dotnet build Quasar.Common.Tests/Quasar.Common.Tests.csproj -c Debug`
- `dotnet test Quasar.Common.Tests/Quasar.Common.Tests.csproj -c Debug --no-build` *(fails: Testhost process not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882fc8a8cc48333968dc9ec4022a870