### PR TITLE
Update target frameworks to net462

### DIFF
--- a/Quasar.Client/Quasar.Client.csproj
+++ b/Quasar.Client/Quasar.Client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>WinExe</OutputType>
     <AssemblyName>Client</AssemblyName>
     <UseWindowsForms>true</UseWindowsForms>

--- a/Quasar.Common.Tests/Quasar.Common.Tests.csproj
+++ b/Quasar.Common.Tests/Quasar.Common.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Quasar.Common/Quasar.Common.csproj
+++ b/Quasar.Common/Quasar.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/Quasar.Server/Quasar.Server.csproj
+++ b/Quasar.Server/Quasar.Server.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>WinExe</OutputType>
     <AssemblyName>Quasar</AssemblyName>
     <UseWindowsForms>true</UseWindowsForms>


### PR DESCRIPTION
## Summary
- bump .NET Framework target from `net452` to `net462`

## Testing
- `dotnet build Quasar.Common/Quasar.Common.csproj -v minimal`
- `dotnet test Quasar.Common.Tests/Quasar.Common.Tests.csproj -v minimal` *(fails: Cannot open assembly 'testhost.exe')*

------
https://chatgpt.com/codex/tasks/task_e_6882ff281cac83339915a63045bf8dce